### PR TITLE
Fix storing overwrite mode

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -495,9 +495,6 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
         .then(function(res) {
             var response = res.data;
             $scope.ladda = false;
-            if (!response.page.allowOverwrite) {
-                $scope.overwrite = "rename";
-            }
 
             // TODO: Add timestamps to invalidate cache!
 


### PR DESCRIPTION
Due to abf549cc239a80f812b56439937aef32fd0508b1, `allowOverwrite` is no longer returned. Thus, the overwrite mode always is being set to `rename`.