### PR TITLE
Proof of concept: use structured data regions

### DIFF
--- a/public_html/locale/en.json
+++ b/public_html/locale/en.json
@@ -21,7 +21,7 @@
     "thumb-dimensions": "Thumbnail: {{width}}\u00d7{{height}} px.",
     "crop-dimensions": "Crop: {{width}}\u00d7{{height}} px.",
     "cropped-dimensions": "Cropped: {{width}}\u00d7{{height}} px.",
-    "cropform-select-region": "Select a crop region by click-and-drag, or try the <a href ng-click=\"{{url}}\">magic border locator<\/a>.",
+    "cropform-select-region": "Select a crop region by click-and-drag, or try the <a href ng-click=\"{{url}}\">magic border locator<\/a>, or <a href ng-click=\"{{url2}}\">select a structured data region<\/a>.",
     "left": "Left",
     "top": "Top",
     "width": "Width",

--- a/src/index.html
+++ b/src/index.html
@@ -267,7 +267,7 @@
                     <input type="hidden" name="title" ng-model="currentUrlParams.title" />
 
                     <p>
-                        <span translate translate-compile translate-value-url="locateBorder()">cropform-select-region</span>
+                        <span translate translate-compile translate-value-url="locateBorder()" translate-value-url2="loadStructuredDataRegions()">cropform-select-region</span>
                         <img src="res/spinner1.gif" ng-show="borderLocatorBusy">
                     </p>
 


### PR DESCRIPTION
Using Structured Data on Commons, users can define which subjects are depicted in an image, and which region of the image they reside in. (One way to define these regions is the [Wikidata Image Positions tool][1], which despite its name also supports Commons.) We can use these regions as a basis for cropping – for example, if an editor has already marked where individual people are located in a group photo, the same data can be used to crop out images of those individuals.

[1]: https://www.wikidata.org/wiki/User:Lucas_Werkmeister/Wikidata_Image_Positions

---

I don’t think this is ready for merging yet, but I hope that you can help me improve it :) there are some TODOs in the source code to indicate what I think is missing. Not all of them are necessary to fix before merging, I think – the most important one is probably the user interface to select one of the depicted regions (instead of [`prompt`](https://developer.mozilla.org/en-US/docs/Web/API/Window/prompt)), which I hope will be easier for you than for me, since you’re more familiar with the UI framework used here.

This is also fully implemented client-side, though I get the general impression that most of this tool is currently implemented server-side, with the client-side code talking to the server to do the heavy lifting. I hope that’s okay with you.

The code should be compatible with all MediaWiki-supported browsers (including IE11), though I’ve only tested it in Firefox 72 so far.