### PR TITLE
Update to recognize new permission template

### DIFF
--- a/src/php/WikiText.php
+++ b/src/php/WikiText.php
@@ -74,6 +74,7 @@ class WikiText
         'User:FlickreviewR\/reviewed-[a-z]+',
         'picture[_ ]of[_ ]week',
         '(permission|Разрешение|ConfirmationImage)? ?OTRS[ -]?(ID|permission)?',
+        'PermissionTicket',
     );
 
     /*

--- a/tests/unit/WikiTextTest.php
+++ b/tests/unit/WikiTextTest.php
@@ -367,10 +367,12 @@ Sault-S<sup>te</sup>-Marie, Ontario, Canada<br>
         $ex1 = new WikiText('abc {{PermissionOTRS|id=123}} def');
         $ex2 = new WikiText('abc {{Разрешение OTRS|id=123}} def');
         $ex3 = new WikiText('abc {{PermissionOTRS-ID|id=123}} def');
+				$ex4 = new WikiText('abc {{PermissionTicket|id=123}} def');
 
         $this->assertEquals('abc def', (string) $ex1->withoutTemplatesNotToBeCopied());
         $this->assertEquals('abc def', (string) $ex2->withoutTemplatesNotToBeCopied());
         $this->assertEquals('abc def', (string) $ex3->withoutTemplatesNotToBeCopied());
+				$this->assertEquals('abc def', (string) $ex4->withoutTemplatesNotToBeCopied());
     }
 
     public function testItDoesntCopyExtractTemplate()


### PR DESCRIPTION
The system knows not to copy over {{PermissionOTRS}}, but that template has recently been renamed to {{PermissionTicket}} due to https://phabricator.wikimedia.org/T280392. This fixes an issue with CropTool tripping an edit filter.