### PR TITLE
Fix and use the JpegFile class for lossless cropping

### DIFF
--- a/src/php/File/File.php
+++ b/src/php/File/File.php
@@ -188,7 +188,7 @@ class File implements FileInterface
         ];
     }
 
-    static public function crop($srcPath, $destPath, $method, $coords, $rotation)
+    public function crop($srcPath, $destPath, $method, $coords, $rotation)
     {
         $image = new Imagick($srcPath);
 

--- a/src/php/File/FileInterface.php
+++ b/src/php/File/FileInterface.php
@@ -16,7 +16,7 @@ interface FileInterface
 
     static public function readMetadata($path);
 
-    static public function crop($srcPath, $destPath, $method, $coords, $rotation);
+    public function crop($srcPath, $destPath, $method, $coords, $rotation);
 
     static public function saveImage($im, $destPath, $srcPath);
 }

--- a/src/php/File/FileRepository.php
+++ b/src/php/File/FileRepository.php
@@ -23,6 +23,8 @@ class FileRepository
     protected function getFileClass($mime)
     {
         switch ($mime) {
+            case 'image/jpeg':
+                return JpegFile::class;
             case 'image/tiff':
                 return TiffFile::class;
             case 'image/vnd.djvu':

--- a/src/php/File/JpegFile.php
+++ b/src/php/File/JpegFile.php
@@ -44,10 +44,11 @@ class JpegFile extends File implements FileInterface
         ];
     }
 
-    static public function crop($srcPath, $destPath, $method, $coords, $rotation)
+    public function crop($srcPath, $destPath, $method, $coords, $rotation)
     {
-        if ($method == 'precise') {
-            return parent::crop($srcPath, $destPath, $method, $coords, $rotation);
+        if ($method === 'precise') {
+            parent::crop($srcPath, $destPath, $method, $coords, $rotation);
+            return;
         }
 
         // Lossless

--- a/src/php/Image.php
+++ b/src/php/Image.php
@@ -2,6 +2,7 @@
 
 namespace CropTool;
 
+use CropTool\File\File;
 use Imagick;
 use ImagickPixel;
 
@@ -18,12 +19,12 @@ class Image
     public $samplingFactor;
     public $width;
     public $height;
-    protected $fileClass;
+    protected $file;
 
-    public function __construct(ImageEditor $editor, string $fileClass, $path, $mime)
+    public function __construct(ImageEditor $editor, File $file, $path, $mime)
     {
         $this->editor = $editor;
-        $this->fileClass = $fileClass;
+        $this->file = $file;
         $this->path = $path;
         $this->mime = $mime;
         $this->load();
@@ -31,7 +32,7 @@ class Image
 
     protected function load()
     {
-        $metadata = $this->fileClass::readMetadata($this->path);
+        $metadata = $this->file::readMetadata($this->path);
 
         if (!$metadata  || !$metadata['width'] || !$metadata['height']) {
             // @TODO: This should move to a safer place:
@@ -178,11 +179,11 @@ class Image
         // Get coords orientated in the same direction as the image:
         $coords = $this->getCropCoordinates($x, $y, $width, $height, $rotation);
 
-        $this->fileClass::crop($this->path, $destPath, $method, $coords, $rotation);
+        $this->file->crop($this->path, $destPath, $method, $coords, $rotation);
 
         chmod($destPath, $this->filePermission);
 
-        return new Image($this->editor, $this->fileClass, $destPath, $this->mime);
+        return new Image($this->editor, $this->file, $destPath, $this->mime);
     }
 
 
@@ -226,7 +227,7 @@ class Image
 
         $im->setImageCompressionQuality(75);
 
-        $this->fileClass::saveImage($im, $thumbPath, $this->path);
+        $this->file::saveImage($im, $thumbPath, $this->path);
         $im->destroy();
 
         return array($w, $h);
@@ -260,6 +261,6 @@ class Image
         $this->genThumb($thumbPath, $this->thumbWidth, $this->thumbHeight);
         chmod($thumbPath, $this->filePermission);
 
-        return new Image($this->editor, $this->fileClass, $thumbPath, $mime);
+        return new Image($this->editor, $this->file, $thumbPath, $mime);
     }
 }

--- a/src/php/ImageEditor.php
+++ b/src/php/ImageEditor.php
@@ -36,6 +36,6 @@ class ImageEditor
 
         $mime = $this->mimeFromPath($path);
 
-        return new Image($this, get_class($file), $path, $mime);
+        return new Image($this, $file, $path, $mime);
     }
 }


### PR DESCRIPTION
The refactoring done in 382d7cc1 left the JpegFile class in an un- usuable state.

Using the classname alone to do a static function call on the crop method in the Image class could not work when the path of jpegtran is configured on the object.

That's the reason why lossless jpeg manipulation did not work. See #170
 
The FileRepository actually does a good job creating objects that fit the file type so they could be used directly in the Image class and so the static call there can just be a call on the specific instance.