### PR TITLE
Make cropping of animated GIF files work

### DIFF
--- a/src/php/File/FileRepository.php
+++ b/src/php/File/FileRepository.php
@@ -33,6 +33,8 @@ class FileRepository
                 return PdfFile::class;
             case 'image/svg+xml':
                 return SvgFile::class;
+            case 'image/gif':
+		return GifFile::class;
             default:
                 return File::class;
         }

--- a/src/php/File/GifFile.php
+++ b/src/php/File/GifFile.php
@@ -6,7 +6,7 @@ use pastuhov\Command\Command;
 
 class GifFile extends File implements FileInterface
 {
-    static public function crop($srcPath, $destPath, $method, $coords, $rotation)
+    public function crop($srcPath, $destPath, $method, $coords, $rotation)
     {
         $dim = $coords['width'] . 'x' . $coords['height'] . '+' . $coords['x'] .'+' . $coords['y'] . '!';
 


### PR DESCRIPTION
Make sure the code is triggered that uses command line image magick for gif files instead of the default crop command.

I tested this locally on my own wiki using File:Logo_dhv.gif. I can confirm that previously this file was not cropped properly, and after the change it was cropped properly.

Fixes #171