### PR TITLE
Avoid warning if image has no categories.

### DIFF
--- a/src/php/QueryResponse.php
+++ b/src/php/QueryResponse.php
@@ -26,7 +26,7 @@ class QueryResponse
             }
             $this->exists = true;
             $this->parseImageInfo($page->imageinfo[0]);
-            $this->parseCategories($page->categories);
+            $this->parseCategories($page->categories ?? []);
         }
     }
 


### PR DESCRIPTION
MW API doesn't return a category structure if there are none which causes php warning

Avoids
```
PHP message: PHP Warning:  Undefined property: stdClass::$categories in /var/www/html/src/php/QueryResponse.php on line 30
array_map(): Argument #2 ($array) must be of type array, null given
```