### PR TITLE
Increase memory limit and turn off display_errors

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -21,11 +21,6 @@ ini_set('display_errors', 'off');
 ini_set('display_startup_errors', 'off');
 ini_set('memory_limit', '512M');
 
-// Encourage ImageMagick to use mmap() instead of the heap, since maps should be
-// released when the request terminates
-Imagick::setResourceLimit( Imagick::RESOURCETYPE_MEMORY, 10_000_000 );
-Imagick::setResourceLimit( Imagick::RESOURCETYPE_MAP, 2_000_000_000 );
-
 /**********************************************************************************
  * The array_get method from Laravel
  *

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -17,10 +17,14 @@ if (!defined('ROOT_PATH')) {
  */
 
 error_reporting(E_ALL);
-ini_set('display_errors', '1');
-ini_set('display_startup_errors', 1);
+ini_set('display_errors', 'off');
+ini_set('display_startup_errors', 'off');
 ini_set('memory_limit', '512M');
 
+// Encourage ImageMagick to use mmap() instead of the heap, since maps should be
+// released when the request terminates
+Imagick::setResourceLimit( Imagick::RESOURCETYPE_MEMORY, 10_000_000 );
+Imagick::setResourceLimit( Imagick::RESOURCETYPE_MAP, 2_000_000_000 );
 
 /**********************************************************************************
  * The array_get method from Laravel

--- a/service.template
+++ b/service.template
@@ -1,3 +1,5 @@
 backend: kubernetes
 type: buildservice
 mount: all
+mem: 2Gi
+cpu: 1


### PR DESCRIPTION
* Increase the pod memory limit from 500MB to 2GB. The logs show OOM
  kills and Commons users report failure to crop large images.
* Increase the CPU limit from 0.5 to 1. Like pressing the turbo button.
* Turn off display_errors. Deprecation warnings are polluting JSON API
  responses, completely breaking the border detection feature.
