### PR TITLE
Always use server side dimensions for client side cropper

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -232,7 +232,7 @@
                      **************************************************************************************************** -->
                 <div ng-show="!cropresults" class="inner cropboxContainer">
 
-                    <img id="cropbox" ng-class="{imageloading: busy}" ct-cropper aspect-ratio="{{aspectratio_cxy}}" rotation="{{rotation.angle}}" on-crop="updateCoords($event.detail)" ng-src="{{metadata.thumb ? metadata.thumb.name : metadata.original.name}}">
+                    <img id="cropbox" ng-class="{imageloading: busy}" ct-cropper aspect-ratio="{{aspectratio_cxy}}" rotation="{{rotation.angle}}" on-crop="updateCoords($event.detail)" ng-src="{{metadata.thumb ? metadata.thumb.name : metadata.original.name}}" width="{{metadata.thumb ? metadata.thumb.width : metadata.original.width}}" height="{{metadata.thumb ? metadata.thumb.height : metadata.original.height}}">
 
                 </div>
 

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -104,6 +104,19 @@ directive('ctCropper', ['$timeout', function($timeout) {
 
             function initCropper() {
                 destroy();
+		// SVG files might not contain an explicit width/height in
+		// which case the size of the browsers viewport is used.
+		// Enforce that we always use the server's calculation for image width/height.
+		Object.defineProperty(
+			element[0],
+			'naturalWidth',
+			{ value: element[0].getAttribute( 'width' ) }
+		);
+		Object.defineProperty(
+			element[0],
+			'naturalHeight',
+			{ value: element[0].getAttribute( 'height' ) }
+		);
                 scope.cropper = new Cropper(element[0], {
                     aspectRatio: scope.aspectRatio,
                     crop: cropperCrop,

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -104,19 +104,19 @@ directive('ctCropper', ['$timeout', function($timeout) {
 
             function initCropper() {
                 destroy();
-		// SVG files might not contain an explicit width/height in
-		// which case the size of the browsers viewport is used.
-		// Enforce that we always use the server's calculation for image width/height.
-		Object.defineProperty(
-			element[0],
-			'naturalWidth',
-			{ value: element[0].getAttribute( 'width' ) }
-		);
-		Object.defineProperty(
-			element[0],
-			'naturalHeight',
-			{ value: element[0].getAttribute( 'height' ) }
-		);
+                // SVG files might not contain an explicit width/height in
+                // which case the size of the browsers viewport is used.
+                // Enforce that we always use the server's calculation for image width/height.
+                Object.defineProperty(
+                        element[0],
+                        'naturalWidth',
+                        { value: element[0].getAttribute( 'width' ) }
+                );
+                Object.defineProperty(
+                        element[0],
+                        'naturalHeight',
+                        { value: element[0].getAttribute( 'height' ) }
+                );
                 scope.cropper = new Cropper(element[0], {
                     aspectRatio: scope.aspectRatio,
                     crop: cropperCrop,


### PR DESCRIPTION
SVG files can potentially have relative widths and heights where their size is relative to the browser size. This causes cropping to fail as the backend and frontend disagree on what size the image is.

This forces the js cropper code to always use the server side width & height, to ensure that everything is in agreement.

Most SVGs specify an absolute width & height so don't have this issue. An example of a file with this issue is https://commons.wikimedia.org/wiki/File:Eclampsia_svg_hariadhi.svg