### PR TITLE
Do not throw error if ratio not specified in url

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -333,7 +333,7 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
                     }
 
                     $scope.crop_dim = crop_dim;
-                    if ($scope.currentUrlParams.ratio !== '' && $scope.currentUrlParams.ratio.split(':').length == 2) {
+                    if (typeof $scope.currentUrlParams.ratio === 'string' && $scope.currentUrlParams.ratio !== '' && $scope.currentUrlParams.ratio.split(':').length == 2) {
                         var parts = $scope.currentUrlParams.ratio.split(':');
                         $scope.aspectratio = 'fixed';
                         $scope.aspectratio_cx = parts[0];


### PR DESCRIPTION
Previously this was throwing an error on client side when ratio was not specified in url, because then ratio would be undefined and string related methods could not be called on it.

This also made the dimensions initially show up as NaN when you first opened an image.