### PR TITLE
Suggest correct file extension when cropping pdf, djvu and tiff

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -368,11 +368,17 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
             if (!response.error) {
 
                 var p = $scope.currentUrlParams.title.lastIndexOf('.');
-                if ($scope.currentUrlParams.page && $scope.metadata.pagecount > 1) {
-                    $scope.newTitle = $scope.currentUrlParams.title.substr(0, p) + ' (page ' + $scope.currentUrlParams.page + ' crop).jpg';
-                } else {
-                    $scope.newTitle = $scope.currentUrlParams.title.substr(0, p) + ' (cropped)' + $scope.currentUrlParams.title.substr(p);
+                var cropText;
+		var ext = $scope.currentUrlParams.title.substr(p);
+                if ( $scope.metadata.overrideResultExtension ) {
+                    ext = '.' + $scope.metadata.overrideResultExtension
                 }
+                if ($scope.currentUrlParams.page && $scope.metadata.pagecount > 1) {
+                    cropText = ' (page ' + $scope.currentUrlParams.page + ' crop)';
+                } else {
+                    cropText = ' (cropped)';
+                }
+                $scope.newTitle = $scope.currentUrlParams.title.substr(0, p) + cropText + ext;
             }
 
         }, function(res) {

--- a/src/php/Controllers/FileController.php
+++ b/src/php/Controllers/FileController.php
@@ -86,6 +86,7 @@ class FileController
             'orientation' => $original->orientation,
             'categories' => $page->imageinfo->categories,
             'supportsRotation' => $page->file->supportsRotation(),
+            'overrideResultExtension' => $page->file->overrideResultExtension()
         ]));
 
         return $response;

--- a/src/php/File/DjvuFile.php
+++ b/src/php/File/DjvuFile.php
@@ -48,4 +48,8 @@ class DjvuFile extends File implements FileInterface
 
         return $jpgFile;
     }
+
+    public function overrideResultExtension() {
+        return 'jpg';
+    }
 }

--- a/src/php/File/File.php
+++ b/src/php/File/File.php
@@ -212,4 +212,11 @@ class File implements FileInterface
     public function supportsRotation() {
         return true;
     }
+
+    /**
+     * Return extension if the cropped result will have different format than original
+     */
+    public function overrideResultExtension() {
+        return false;
+    }
 }

--- a/src/php/File/FileInterface.php
+++ b/src/php/File/FileInterface.php
@@ -21,4 +21,6 @@ interface FileInterface
     static public function saveImage($im, $destPath, $srcPath);
 
     public function supportsRotation();
+
+    public function overrideResultExtension();
 }

--- a/src/php/File/PdfFile.php
+++ b/src/php/File/PdfFile.php
@@ -37,4 +37,8 @@ class PdfFile extends File implements FileInterface
 
         return $jpgFile;
     }
+
+    public function overrideResultExtension() {
+        return 'jpg';
+    }
 }


### PR DESCRIPTION
Previously this was suggesting a .jpg extension for multipage files and keeping the same extension for everything else.

However, single page .pdf and .djvu should still have the .jpg extension. Multipage .tiff files should keep .tiff and not be .jpg

This was causing upload failures unless the user noticed and changes the extension.

Some examples of affected files: File:adrenaline_ampoule.pdf or File:1898_circa_Willy_Hoehl_Gruss_vom_Nordstädter_Gesellschaftshaus_Gustav_Fischer,_Oberstraße_7_und_8,_Adressseite.tif 