### PR TITLE
Add better error handling

### DIFF
--- a/src/js/app.js
+++ b/src/js/app.js
@@ -300,6 +300,11 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
                 $scope.metadata = null;
                 return;
             }
+            if ( res.data?.exception?.[0]?.message ) {
+                $scope.error = res.data.exception[0].message;
+                $scope.metadata = null;
+                return;
+            }
 
             $scope.metadata = response;
 
@@ -377,7 +382,7 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
 
         }, function(res) {
             $scope.metadata = null;
-            $scope.error = res.data.error;
+            $scope.error = res.data?.exception?.[0]?.message ?? res.data.error;
             $scope.busy = false;
         });
     }
@@ -403,7 +408,8 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
                 height: (area[3] - area[1]) / pixelratio[1]
             });
         }, function(res) {
-            $scope.error = 'An error occurred: ' + res.status + ' ' + res.data.error;
+            $scope.error = 'An error occurred: ' + res.status + ' ' +
+                ( res.data?.exception?.[0]?.message ?? res.data.error );
             $scope.borderLocatorBusy = false;
         });
     };
@@ -581,7 +587,7 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
             }
             $scope.updateUploadComment();
         }, function(res) {
-            $scope.error = '[Error] ' + res.data.error;
+            $scope.error = '[Error] ' + ( res.data?.exception?.[0]?.message ?? res.data.error );
             $scope.ladda = false;
         });
 
@@ -644,7 +650,7 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
 
         }, function(res) {
             $scope.ladda2 = false;
-            $scope.error = 'Upload failed! ' + res.data.error;
+            $scope.error = 'Upload failed! ' + (res.data?.exception?.[0]?.message ?? res.data.error);
         });
 
     };
@@ -720,6 +726,8 @@ controller('AppCtrl', ['$scope', '$http', '$timeout', '$q', '$window', '$httpPar
 
                 if (response.error) {
                     $scope.error = response.error;
+		} else if ( res.data?.exception?.[0]?.message ) {
+			$scope.error = res.data.exception[0].message;
                 } else {
                     $scope.exists[key] = response.exists;
                     // console.log($scope.exists);


### PR DESCRIPTION
Errors that were exceptions were not being communicated to the user.

This lead to most error conditions being communicated to the user as "undefined".

For example if you tried to crop an image with {{licensereview}} on it. This was very confusing.

Fixes #194 