### PR TITLE
Fix handling of quotes in SVG.

### DIFF
--- a/src/php/File/SvgFile.php
+++ b/src/php/File/SvgFile.php
@@ -173,9 +173,9 @@ class SvgFile extends File implements FileInterface
                 $openingElm = '<' . $reader->name;
                 $closingElm = '</' . $reader->name . '>';
 
-                $openingElm .= ' width="' . htmlspecialchars( $coords['width'], ENT_XML1 ) . '"';
-                $openingElm .= ' height="' . htmlspecialchars( $coords['height'], ENT_XML1 ) . '"';
-                $openingElm .= ' viewBox="' . htmlspecialchars( $newViewBox, ENT_XML1 ) . '"';
+                $openingElm .= ' width="' . htmlspecialchars( $coords['width'], ENT_XML1 | ENT_QUOTES ) . '"';
+                $openingElm .= ' height="' . htmlspecialchars( $coords['height'], ENT_XML1 | ENT_QUOTES ) . '"';
+                $openingElm .= ' viewBox="' . htmlspecialchars( $newViewBox, ENT_XML1 | ENT_QUOTES ) . '"';
                 while( $reader->moveToNextAttribute() ) {
                     if (
                         $reader->namespaceURI === '' &&
@@ -183,7 +183,7 @@ class SvgFile extends File implements FileInterface
                         continue;
                     }
                     $openingElm .= ' ' . $reader->name . '=';
-                    $openingElm .= '"' . htmlspecialchars( $reader->value, ENT_XML1 ) . '"';
+                    $openingElm .= '"' . htmlspecialchars( $reader->value, ENT_XML1 | ENT_QUOTES ) . '"';
                 }
 
                 $openingElm .= '>';


### PR DESCRIPTION
PHP is confusing. I assumed that htmlspecialchars( $foo, ENT_XML1 ) would escape quote characters, but turns out you also need to provide | ENT_QUOTES.

An example file where this causes a problem is
File:Parkinsons-disease-prevalence-ihme,World,2021.svg on commons.